### PR TITLE
Native modes and scaler setting

### DIFF
--- a/bmd-streamer.c
+++ b/bmd-streamer.c
@@ -132,12 +132,21 @@ static struct display_mode *display_modes[DMODE_MAX] = {
 	},
 	[DMODE_720x576i_25] = &(struct display_mode){
 		.description = "576i 25",
-		.width = 720, .height = 576, .interlaced = 1, .program_fpga = 1,
+		.width = 720, .height = 576, .interlaced = 0, .program_fpga = 1,
 		.fps_numerator = 25, .fps_denominator = 1, .fx2_fps = 0x3,
 		.audio_delay = 0x30, .ain_offset = 0x0000,
 		.r1000 = 0x0500, .r1404 = 0x0071, .r140a = 0x17ff, .r1430_l = 0xff,
 		.r147x = { 0x10, 0x70, 0x70, 0x10 },
 		.r154x = { 0x1050, 0x0000, 0x07ff, 0x0360, 0x0271, 0x0090, 0x002e, 0x07ff, 0x02d0, 0x0240, 0x0019 },
+		.native_mode = &(struct display_mode){
+			.description = "576i 25",
+			.width = 720, .height = 576, .interlaced = 1, .program_fpga = 0,
+			.fps_numerator = 25, .fps_denominator = 1, .fx2_fps = 0x3,
+			.audio_delay = 0x30, .ain_offset = 0x0000,
+			.r1000 = 0x0100, .r1404 = 0x0071, .r140a = 0x1005, .r1430_l = 0x00,
+			.r147x = { 0x26, 0x7d, 0x56, 0x07 },
+			.r154x = { 0x0100, 0x0001, 0x07ff, 0x06c0, 0x0271, 0x0120, 0x0017, 0x07ff, 0x05a0, 0x0120, 0x0000 },
+		},
 	},
 	/* DMODE_720x480p_59_94 */
 	/* DMODE_720x576p_50 */

--- a/bmd-streamer.c
+++ b/bmd-streamer.c
@@ -44,6 +44,7 @@ struct encoding_parameters {
 	char *		exec_program;
 	int		respawn : 1;
 	int		native_mode : 1;
+	int		src_x, src_y, src_width, src_height, dst_width, dst_height;
 };
 
 static int do_syslog = 0;
@@ -63,6 +64,12 @@ static struct encoding_parameters ep = {
 	.fps_divider = 1,
 	.input_source = -1,
 	.native_mode = 0,
+	.src_x = 0,
+	.src_y = 0,
+	.src_width = 0,
+	.src_height = 0,
+	.dst_width = 0,
+	.dst_height = 0,
 };
 
 static const char *input_source_names[5] = {
@@ -863,18 +870,17 @@ static int bmd_configure_encoder(struct blackmagic_device *bmd, struct encoding_
 	}
 
 	/* Group 5 - Scaler / H.264 encoder */
-	if (0 /*target_mode*/) {
+	if (ep->src_x || ep->src_y || ep->src_width || ep->src_height || ep->dst_width || ep->dst_height) {
 		// bit 0x8000 resolution converter enabled
 		// bit 0x00ff conversion target, 0=no conversion, 4=NTSC, 5=PAL, 0xff=progressive
+
 		bmd_fujitsu_write(bmd, 0x001520, 0x80ff);
-		/*
-		bmd_fujitsu_write(bmd, 0x001522, ep->mode->src_xoffs);	// src x offset
-		bmd_fujitsu_write(bmd, 0x001524, ep->mode->src_yoffs);	// src y offset
-		bmd_fujitsu_write(bmd, 0x001526, ep->mode->src_width);	// src width
-		bmd_fujitsu_write(bmd, 0x001528, ep->mode->src_height);// src height (1080)
-		bmd_fujitsu_write(bmd, 0x00152e, ep->mode->dst_width);	// dst width
-		bmd_fujitsu_write(bmd, 0x001530, ep->mode->dst_height);// dst height (1088)
-		*/
+		bmd_fujitsu_write(bmd, 0x001522, ep->src_x);	// src x offset
+		bmd_fujitsu_write(bmd, 0x001524, ep->src_y);	// src y offset
+		bmd_fujitsu_write(bmd, 0x001526, (ep->src_width)?ep->src_width:current_mode->width);	// src width
+		bmd_fujitsu_write(bmd, 0x001528, (ep->src_height)?ep->src_height:current_mode->height);// src height (1080)
+		bmd_fujitsu_write(bmd, 0x00152e, (ep->dst_width)?ep->dst_width:current_mode->width);	// dst width
+		bmd_fujitsu_write(bmd, 0x001530, (ep->dst_height)?ep->dst_height:current_mode->height);// dst height (1088)
 	} else if (current_mode->convert_to_1088) {
 		/* Convert to height 1088 */
 		bmd_fujitsu_write(bmd, 0x001520, 0x80ff);
@@ -894,8 +900,8 @@ static int bmd_configure_encoder(struct blackmagic_device *bmd, struct encoding_
 		bmd_fujitsu_write(bmd, 0x001530, 0);	// dst height
 	}
 	bmd_fujitsu_write(bmd, 0x0015a0, (ep->h264_profile << 14) | ep->h264_level);
-	bmd_fujitsu_write(bmd, 0x0015a2, (current_mode->width + 15) >> 4);
-	bmd_fujitsu_write(bmd, 0x0015a4, (current_mode->height + 15) >> 4);
+	bmd_fujitsu_write(bmd, 0x0015a2, (((ep->dst_width)?ep->dst_width:current_mode->width) + 15) >> 4);
+	bmd_fujitsu_write(bmd, 0x0015a4, (((ep->dst_height)?ep->dst_height:current_mode->height) + 15) >> 4);
 	bmd_fujitsu_write(bmd, 0x0015a6, current_mode->fps_denominator); // divider
 	bmd_fujitsu_write(bmd, 0x0015a8, 2*current_mode->fps_numerator/ep->fps_divider >> 16);
 	bmd_fujitsu_write(bmd, 0x0015aa, 2*current_mode->fps_numerator/ep->fps_divider & 0xffff);
@@ -1313,6 +1319,12 @@ int main(int argc, char **argv)
 		{ "respawn",		no_argument, NULL, 'R' },
 		{ "syslog",		no_argument, NULL, 's' },
 		{ "native",		no_argument, NULL, 'n' },
+		{ "src-x",		required_argument, NULL, '0' },
+		{ "src-y",		required_argument, NULL, '1' },
+		{ "src-width",		required_argument, NULL, '2' },
+		{ "src-height",		required_argument, NULL, '3' },
+		{ "dst-width",		required_argument, NULL, '4' },
+		{ "dst-height",		required_argument, NULL, '5' },
 		{ NULL }
 	};
 	static const char short_options[] = "vk:K:a:P:L:bcBCF:f:S:x:Rsn";
@@ -1362,6 +1374,12 @@ int main(int argc, char **argv)
 			ep.input_source = i;
 			break;
 		case 'n': ep.native_mode = 1; break;
+		case '0': ep.src_x = atoi(optarg); break;
+		case '1': ep.src_y = atoi(optarg); break;
+		case '2': ep.src_width = atoi(optarg); break;
+		case '3': ep.src_height = atoi(optarg); break;
+		case '4': ep.dst_width = atoi(optarg); break;
+		case '5': ep.dst_height = atoi(optarg); break;
 		default:
 			return usage();
 		}


### PR DESCRIPTION
proposed commits implements native modes for 1080i50 and PAL that helps to get interlaced video. 

other addons implement scaler settings which helps to produce 480p streaming modes for some reason (it actually has a limitation, for Progressive PAL scaled resolution width greater then 768 gives strange artifact, but it works)

thanks for that project - you did a great job!
